### PR TITLE
Fix typo in github username

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ email_address                             : dev@getutm.app
 facebook_username                         :                                           
 instagram_username                        : 
 twitter_username                          : 
-github_username                           : utmap
+github_username                           : utmapp
 discord_address                           : https://discord.gg/UV2RUgD
 
 


### PR DESCRIPTION
A typo in the github username caused the footer github link to go to the wrong profile.